### PR TITLE
Replaced `path` module with `upath` to add support for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "https://github.com/luke3butler/feathers-versionate.git"
   },
   "dependencies": {
-    "uberproto": "^1.2.0"
+    "uberproto": "^1.2.0",
+    "upath": "^1.1.0"
   },
   "engines": {
     "node": ">= 6.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,18 @@
 'use strict';
-const path = require('path');
+const path = require('upath');
 const Proto = require('uberproto');
 
 const service = function (name, basePath, subItem = false) {
   const app = this;
 
-  // Relay use to app.use with basePath applied  
+  // Relay use to app.use with basePath applied
   const use = function () {
     const args = Array.from(arguments);
     const subPath = args.shift();
     app.use(path.join(basePath, subPath), ...args);
   }
 
-  // Relay service to app.service with basePath applied  
+  // Relay service to app.service with basePath applied
   const service = function (subPath) {
     return app.service(path.join(basePath, subPath));
   }
@@ -27,7 +27,7 @@ const service = function (name, basePath, subItem = false) {
   // Return new service methods
   return (subItem === true)
     // Nest under versionate if flag set to true
-    ? { versionate: newService } 
+    ? { versionate: newService }
     : newService;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2947,6 +2947,10 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
+upath@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
+
 update-notifier@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.2.0.tgz#1b5837cf90c0736d88627732b661c138f86de72f"


### PR DESCRIPTION
`path` module uses platform specific separator, so everything breaks in Windows because path.join uses the wrong separator char.